### PR TITLE
remove 64-bit memory addressing requirement

### DIFF
--- a/DBFcull/README.md
+++ b/DBFcull/README.md
@@ -11,6 +11,5 @@ If a listed field is not contained in the DBF file, it is ignored.<br>
 If no listed fields are contained in the DBF file, the output file will be identical to the input file.
 
 **Notes:**<br>
-Program requires 64-bit memory addressing and little-endian (Intel) byte order.<br>
-It will not work in other environments.<br>
-This could be fixed/improved, but is a low priority.
+Program requires little-endian (Intel) byte order.<br>
+Adapting it to big-endian (Motorola) is not a priority.

--- a/DBFmine/README.md
+++ b/DBFmine/README.md
@@ -8,6 +8,5 @@ Useful for getting lists of route numbers, seeing if a given field is useful or 
 `DBFmine DBFname KeyField`
 
 **Notes:**<br>
-Program requires 64-bit memory addressing and little-endian (Intel) byte order.<br>
-It will not work in other environments.<br>
-This could be fixed/improved, but is a low priority.
+Program requires little-endian (Intel) byte order.<br>
+Adapting it to big-endian (Motorola) is not a priority.

--- a/DBFtrim/DBFtrim.cpp
+++ b/DBFtrim/DBFtrim.cpp
@@ -40,11 +40,11 @@ int main(int argc, char *argv[])
 		cout << '\t' << oDBF.fArr[i].type;
 		cout << '\t' << int(oDBF.fArr[i].len);
 		cout << '\t' << int(tDBF.fArr[i].len);
-		cout << '\t' << oDBF.fArr[i].MaxVal;
+		cout << '\t' << tDBF.MaxVal[i];
 		    if (oDBF.fArr[i].MinEx0)
-		    {	if (strchr(oDBF.fArr[i].MaxVal, '.')) oDBF.fArr[i].MaxVal[tDBF.fArr[i].len] = '0';
-			else oDBF.fArr[i].MaxVal[tDBF.fArr[i].len] = '.';
-			cout << " <- " << oDBF.fArr[i].MaxVal;
+		    {	if (strchr(tDBF.MaxVal[i], '.')) tDBF.MaxVal[i][tDBF.fArr[i].len] = '0';
+			else tDBF.MaxVal[i][tDBF.fArr[i].len] = '.';
+			cout << " <- " << tDBF.MaxVal[i];
 		    }
 		cout << endl;
 	}

--- a/DBFtrim/README.md
+++ b/DBFtrim/README.md
@@ -8,6 +8,5 @@ This often results in substantial file size savings, which in turn can lead to f
 `DBFtrim InputFile OutputFile`
 
 **Notes:**<br>
-Program requires 64-bit memory addressing and little-endian (Intel) byte order.<br>
-It will not work in other environments.<br>
-This could be fixed/improved, but is a low priority.
+Program requires little-endian (Intel) byte order.<br>
+Adapting it to big-endian (Motorola) is not a priority.

--- a/lib/field.cpp
+++ b/lib/field.cpp
@@ -6,26 +6,26 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 	switch (type)
 	{   case 'C':
 		// init
-		if (!MaxVal)
+		if (!tDBF.MaxVal[fNum])
 		{	tDBF.fArr[fNum].len = 0;
-			MaxVal = new char[1]; MaxVal[0] = 0;
+			tDBF.MaxVal[fNum] = new char[1]; tDBF.MaxVal[fNum][0] = 0;
 		}
 		// trim whitespace
 		while (fVal[strlen(fVal)-1] <= ' ' && fVal[strlen(fVal)-1] > 0) fVal[strlen(fVal)-1] = 0;
 		// compare
 		if (strlen(fVal) > tDBF.fArr[fNum].len)
 		{	tDBF.fArr[fNum].len = strlen(fVal);
-			delete[] MaxVal;
-			MaxVal = fVal;
+			delete[] tDBF.MaxVal[fNum];
+			tDBF.MaxVal[fNum] = fVal;
 		}
 		else delete[] fVal;
 		return;
 
 	    case 'F':
 		// init
-		if (!MaxVal)
+		if (!tDBF.MaxVal[fNum])
 		{	tDBF.fArr[fNum].len = 0;
-			MaxVal = new char[1]; MaxVal[0] = 0;
+			tDBF.MaxVal[fNum] = new char[1]; tDBF.MaxVal[fNum][0] = 0;
 		}
 		// trim whitespace
 		for (pad = 0; (fVal[pad] <= ' ') && pad < len; pad++);
@@ -36,17 +36,17 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 		// compare
 		if (strlen(fVal) > tDBF.fArr[fNum].len)
 		{	tDBF.fArr[fNum].len = strlen(fVal);
-			delete[] MaxVal;
-			MaxVal = fVal;
+			delete[] tDBF.MaxVal[fNum];
+			tDBF.MaxVal[fNum] = fVal;
 		}
 		else delete[] fVal;
 		return;
 
 	    case 'N':
 		// init
-		if (!MaxVal)
+		if (!tDBF.MaxVal[fNum])
 		{	tDBF.fArr[fNum].len = 0;
-			MaxVal = new char[1]; MaxVal[0] = 0;
+			tDBF.MaxVal[fNum] = new char[1]; tDBF.MaxVal[fNum][0] = 0;
 			if (strchr(fVal, '.')) MinEx0 = 255;
 		}
 		// trim leading whitespace
@@ -68,19 +68,19 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 		// compare
 		if (strlen(fVal) > tDBF.fArr[fNum].len+MinEx0)
 		{	tDBF.fArr[fNum].len = strlen(fVal)-MinEx0;
-			delete[] MaxVal;
-			MaxVal = fVal;
-			MaxVal[tDBF.fArr[fNum].len] = 0;
+			delete[] tDBF.MaxVal[fNum];
+			tDBF.MaxVal[fNum] = fVal;
+			tDBF.MaxVal[fNum][tDBF.fArr[fNum].len] = 0;
 		}
 		else delete[] fVal;
 		return;
 
 	    default:
 		delete[] fVal;
-		if (!MaxVal) // ELSE case should only ever be "  <Type ? fields unsupported>", where '?' is field type
-		{	MaxVal = new char[30];
-			strcpy(MaxVal, "  <Type ? fields unsupported>");
-			MaxVal[8] = type;
+		if (!tDBF.MaxVal[fNum]) // ELSE case should only ever be "  <Type ? fields unsupported>", where '?' is field type
+		{	tDBF.MaxVal[fNum] = new char[30];
+			strcpy(tDBF.MaxVal[fNum], "  <Type ? fields unsupported>");
+			tDBF.MaxVal[fNum][8] = type;
 		}
 	}
 }

--- a/lib/field.h
+++ b/lib/field.h
@@ -4,12 +4,11 @@ class field
 {	public:
 	char name[11];	// 11 B on disk; 10 B practical storage space. Final element is null terminator.
 	char type;	// Field type in ASCII (B, C, D, F, G, L, M, or N).
-	unsigned int DataAddx;
+	unsigned int reserved1;
 	unsigned char len;
 	unsigned char DecCount;
-	char padding[5];
 	unsigned char MinEx0;
-	char *MaxVal; // only works with 64-bit memory addressing, E.G. x86-64
+	char reserved2[13];
 	// No more variables! Must be able to write/read a whole array to/from disk.
 	void GetMax(DBF&, unsigned int, char*);
-}; //WARNING: functionality is predicated on sizeof(field) being 32 bytes. Meaning, 64-bit memory addressing; see comment for *MaxVal above
+};


### PR DESCRIPTION
Size of a char* was required to be 8 bytes.
Not anymore.