### PR TITLE
simplify field::GetMax, phase 1

### DIFF
--- a/DBFtrim/DBFtrim.cpp
+++ b/DBFtrim/DBFtrim.cpp
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
 	DBF tDBF(oDBF);		tDBF.InitCopy(oDBF);	// t is for trimmed
 
 	// gather field info
-	ifstream inDBF(argv[1]);
+	ifstream inDBF(oDBF.name);
 	inDBF.seekg(oDBF.HeaLen);
 	cout << "Scanning DBF file...\n";
 	for (unsigned int rNum = 0; rNum < oDBF.NumRec && inDBF.tellg() < oDBF.size; rNum++)
@@ -42,8 +42,9 @@ int main(int argc, char *argv[])
 		cout << '\t' << int(tDBF.fArr[i].len);
 		cout << '\t' << tDBF.MaxVal[i];
 		    if (oDBF.fArr[i].MinEx0)
-		    {	if (strchr(tDBF.MaxVal[i], '.')) tDBF.MaxVal[i][tDBF.fArr[i].len] = '0';
-			else tDBF.MaxVal[i][tDBF.fArr[i].len] = '.';
+		    {	if (strchr(tDBF.MaxVal[i], '.'))
+				tDBF.MaxVal[i][tDBF.fArr[i].len] = '0';
+			else	tDBF.MaxVal[i][tDBF.fArr[i].len] = '.';
 			cout << " <- " << tDBF.MaxVal[i];
 		    }
 		cout << endl;

--- a/lib/dbf.cpp
+++ b/lib/dbf.cpp
@@ -52,12 +52,17 @@ class DBF
 		MaxVal = new char*[NumFields];
 		memcpy(fArr, oDBF.fArr, 32*NumFields);
 		for (unsigned int i = 0; i < NumFields; i++)
-		{	if (fArr[i].MinEx0)
-			{	fArr[i].MinEx0 = 0;
-				std::cout << "Warning: overwriting reserved nonzero bytes in field #" << i << ", " << fArr[i].name << '\n';
-			}
-			MaxVal[i] = 0;
-		}
+		  switch (fArr[i].type)
+		  { case 'N':	oDBF.fArr[i].MinEx0 = 255;
+		    case 'C':	case 'F':
+			MaxVal[i] = new char[1]; MaxVal[i][0] = 0;
+			fArr[i].len = 0;
+			break;
+		    default:
+			MaxVal[i] = new char[30];
+			strcpy(MaxVal[i], "  <Type ? fields unsupported>");
+			MaxVal[i][8] = fArr[i].type;
+		  }
 	}
 
 	void SetRecLen()

--- a/lib/field.cpp
+++ b/lib/field.cpp
@@ -5,11 +5,6 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 	char* NewVal;
 	switch (type)
 	{   case 'C':
-		// init
-		if (!tDBF.MaxVal[fNum])
-		{	tDBF.fArr[fNum].len = 0;
-			tDBF.MaxVal[fNum] = new char[1]; tDBF.MaxVal[fNum][0] = 0;
-		}
 		// trim whitespace
 		while (fVal[strlen(fVal)-1] <= ' ' && fVal[strlen(fVal)-1] > 0) fVal[strlen(fVal)-1] = 0;
 		// compare
@@ -22,11 +17,6 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 		return;
 
 	    case 'F':
-		// init
-		if (!tDBF.MaxVal[fNum])
-		{	tDBF.fArr[fNum].len = 0;
-			tDBF.MaxVal[fNum] = new char[1]; tDBF.MaxVal[fNum][0] = 0;
-		}
 		// trim whitespace
 		for (pad = 0; (fVal[pad] <= ' ') && pad < len; pad++);
 		NewVal = new char[strlen(fVal+pad)+1];
@@ -43,12 +33,6 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 		return;
 
 	    case 'N':
-		// init
-		if (!tDBF.MaxVal[fNum])
-		{	tDBF.fArr[fNum].len = 0;
-			tDBF.MaxVal[fNum] = new char[1]; tDBF.MaxVal[fNum][0] = 0;
-			if (strchr(fVal, '.')) MinEx0 = 255;
-		}
 		// trim leading whitespace
 		for (pad = 0; (fVal[pad] <= ' ') && pad < len; pad++);
 		NewVal = new char[strlen(fVal+pad)+1];
@@ -65,6 +49,7 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 				if (MinEx0 == DecCount) MinEx0++; // decimal point itself is extraneous
 			}
 		}
+		else MinEx0 = 0;
 		// compare
 		if (strlen(fVal) > tDBF.fArr[fNum].len+MinEx0)
 		{	tDBF.fArr[fNum].len = strlen(fVal)-MinEx0;
@@ -74,13 +59,5 @@ void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 		}
 		else delete[] fVal;
 		return;
-
-	    default:
-		delete[] fVal;
-		if (!tDBF.MaxVal[fNum]) // ELSE case should only ever be "  <Type ? fields unsupported>", where '?' is field type
-		{	tDBF.MaxVal[fNum] = new char[30];
-			strcpy(tDBF.MaxVal[fNum], "  <Type ? fields unsupported>");
-			tDBF.MaxVal[fNum][8] = type;
-		}
 	}
 }


### PR DESCRIPTION
Initialization of MaxVal, len, & MinEx0 moved from field::GetMax to DBF::InitCopy.
* This only needs to happen once. Removing unnecessary IF statements repeated dozens of thousands of times will improve speed slightly.
* Remove clutter; simplify field::GetMax
* A step toward convergence of Type C/F/N GetMax routines