### PR TITLE
DBFtrim: trim extraneous 0s in type F fields

### DIFF
--- a/lib/dbf.cpp
+++ b/lib/dbf.cpp
@@ -52,10 +52,12 @@ class DBF
 		MaxVal = new char*[NumFields];
 		memcpy(fArr, oDBF.fArr, 32*NumFields);
 		for (unsigned int i = 0; i < NumFields; i++)
-		{	oDBF.fArr[i].MinEx0 = 0; // Just in case. Can potentially read in a nonzero byte from file.
+		{	oDBF.fArr[i].MinEx0 = 0; // Just in case.
+			oDBF.fArr[i].MaxIntD = 0; // Can potentially read in a nonzero byte from file.
 			switch (fArr[i].type)
-			{   case 'N':	oDBF.fArr[i].MinEx0 = 255;
-			    case 'C':	case 'F':
+			{   case 'N':	case 'F':
+				oDBF.fArr[i].MinEx0 = 255;
+			    case 'C':
 				MaxVal[i] = new char[1]; MaxVal[i][0] = 0;
 				fArr[i].len = 0;
 				break;

--- a/lib/field.h
+++ b/lib/field.h
@@ -4,11 +4,12 @@ class field
 {	public:
 	char name[11];	// 11 B on disk; 10 B practical storage space. Final element is null terminator.
 	char type;	// Field type in ASCII (B, C, D, F, G, L, M, or N).
-	unsigned int reserved1;
+	char reserved1[4];
 	unsigned char len;
 	unsigned char DecCount;
-	unsigned char MinEx0;
-	char reserved2[13];
+	unsigned char MinEx0;	// Minimum extraneous 0s. Not part of DBF spec; stored in reserved bytes for use by DBFtrim.
+	unsigned char MaxIntD;	// Maximum Integer digits. Not part of DBF spec; stored in reserved bytes for use by DBFtrim.
+	char reserved2[12];
 	// No more variables! Must be able to write/read a whole array to/from disk.
 	void GetMax(DBF&, unsigned int, char*);
 };


### PR DESCRIPTION
Plus fixes for a few bugs uncovered in the process:
* All-whitespace values would prevent trimming of extraneous 0s in the same field in other records. Fixed.
* Decimal values >= 10 could have leading numeral(s) improperly trimmed off in some circumstances. Fixed.
* Prevent wraparound when more extraneous 0s are trimmed than DecCount value of original file; E.G. "0.0000000000", & DecCount = 0

This closes #6.