### PR TITLE
DBFtrim: nix MaxIntD for ints; trim extraneous leading 0s

### DIFF
--- a/DBFtrim/DBFtrim.cpp
+++ b/DBFtrim/DBFtrim.cpp
@@ -20,7 +20,7 @@ void RecWrite(DBF oDBF, DBF tDBF, char* outFN, unsigned int ThreadNum, unsigned 
 			inDBF.read(fVal, oDBF.fArr[fNum].len);
 			unsigned char vlen = strlen(fVal);
 			unsigned char fI; // field value index
-			if (oDBF.fArr[fNum].type == 'N' || oDBF.fArr[fNum].type == 'F') fTrim(fVal, vlen);
+			if (oDBF.fArr[fNum].type == 'N' || oDBF.fArr[fNum].type == 'F') fTrim(fVal, vlen, oDBF.fArr[fNum].type);
 			switch (oDBF.fArr[fNum].subtype(fVal))
 			{   case 2: // decimal
 				if (vlen > strchr(fVal, '.') - fVal + 1 + tDBF.fArr[fNum].DecCount)
@@ -32,7 +32,7 @@ void RecWrite(DBF oDBF, DBF tDBF, char* outFN, unsigned int ThreadNum, unsigned 
 				outDBF.write(fVal, vlen);
 				break;
 			    case 'C':
-				fTrim(fVal, vlen);
+				fTrim(fVal, vlen, oDBF.fArr[fNum].type);
 				outDBF << fVal;
 				for (fI = vlen; fI < tDBF.fArr[fNum].len; fI++) outDBF.put(' ');
 				break;

--- a/lib/field.cpp
+++ b/lib/field.cpp
@@ -1,11 +1,12 @@
 #include "dbf.cpp"
 
-void fTrim(char* fVal, unsigned char &vlen)
+void fTrim(char* fVal, unsigned char &vlen, char type)
 {	unsigned char pad;
 	// trim whitespace RIGHT
-	for (int i = vlen-1; fVal[i] <= ' ' && fVal[i] > 0 && i >= 0; i--) { fVal[i] = 0; vlen--; }
-	// trim whitespace LEFT
+	for (int i = vlen-1; fVal[i] <= ' ' && i >= 0; i--) { fVal[i] = 0; vlen--; }
+	// trim whitespace LEFT & extraneous leading zeros
 	for (pad = 0; fVal[pad] <= ' ' && pad < vlen; pad++);
+	if (type != 'C' && pad < vlen-1) while (fVal[pad] == '0' && fVal[pad+1] == '0') pad++;
 	vlen -= pad;
 	for (unsigned char i = 0; i <= vlen; i++) fVal[i] = fVal[pad+i];
 }
@@ -13,13 +14,10 @@ void fTrim(char* fVal, unsigned char &vlen)
 void field::GetMax(DBF& tDBF, unsigned int fNum, char* fVal)
 {	unsigned char vlen = strlen(fVal);
 	unsigned char IntD;
-	fTrim(fVal, vlen);
+	fTrim(fVal, vlen, type);
 	// trim extraneous trailing zeros
 	switch (subtype(fVal))
-	{   case 1: // integer
-		if (MaxIntD < vlen) MaxIntD = vlen;
-		break;
-	    case 2: // decimal
+	{   case 2: // decimal
 		IntD = strchr(fVal, '.') - fVal;
 		if (MaxIntD < IntD) MaxIntD = IntD;
 		unsigned char fI;


### PR DESCRIPTION
* **Nix MaxIntD for ints**
Values of E.G. `100000` and `0.0125` would result in a field length of 10 (when field length in original file >= 10), when only 6 is necessary.
Fixed; now using *MaxIntD* for only decimal values.

* **Trim extraneous leading 0s**
This should be obvious. :)